### PR TITLE
Resolve hard coded paths to the P drive

### DIFF
--- a/client/ayon_nuke/startup/jesse_send.py
+++ b/client/ayon_nuke/startup/jesse_send.py
@@ -4,7 +4,9 @@ from pathlib import Path
 from datetime import datetime
 from PySide2.QtCore import QTimer
 
-NODE_LOCATION = Path(r"P:\dev\alexh_dev\jesseSend")
+# Changing node locations for jesse send to the T drive
+#NODE_LOCATION = Path(r"P:\dev\alexh_dev\jesseSend")
+NODE_LOCATION = Path(r"T:\util\nuke\scripts\jesseSend")
 
 """
 This system allows users to copy a kind of URL associated with a scriptlet, and paste

--- a/client/ayon_nuke/startup/minimal_sequence_factory.py
+++ b/client/ayon_nuke/startup/minimal_sequence_factory.py
@@ -11,9 +11,17 @@ from typing import List, Optional, Union
 # Import the needed classes from file_sequence if possible
 try:
     # Try to import the full module first
+
+    startup = os.path.dirname(__file__)
+    fs_loc = startup + "/file_sequence/file_sequence.py"
+
+    # fs_spec = importlib.util.spec_from_file_location(
+    #     "file_sequence",
+    #     "P:/dev/alexh_dev/ayon_v2/hornet/ayon-nuke/client/ayon_nuke/startup/file_sequence/file_sequence.py",
+    # )
     fs_spec = importlib.util.spec_from_file_location(
         "file_sequence",
-        "P:/dev/alexh_dev/ayon_v2/hornet/ayon-nuke/client/ayon_nuke/startup/file_sequence/file_sequence.py",
+        fs_loc,
     )
     fs_module = importlib.util.module_from_spec(fs_spec)
     fs_spec.loader.exec_module(fs_module)

--- a/client/ayon_nuke/startup/publish_force_import.py
+++ b/client/ayon_nuke/startup/publish_force_import.py
@@ -1,6 +1,7 @@
 import importlib.util
 import sys
-
+import os
+import nuke
 """
 Deadline nuke instances launched from staging are failing to import the modules.
 It appears that they don't inherit the new ayon_nuke environment.
@@ -22,10 +23,14 @@ except ImportError as import_error:
     print(f"Normal imports failed ({import_error}), using force import...")
 
     try:
-        # File paths
-        hdu_loc = "P:/dev/alexh_dev/ayon_v2/hornet/ayon-nuke/client/ayon_nuke/startup/hornet_deadline_utils.py"
-        dprm_loc = "P:/dev/alexh_dev/ayon_v2/hornet/ayon-nuke/client/ayon_nuke/startup/hornet_publish_review_media.py"
-        fs_loc = "P:/dev/alexh_dev/ayon_v2/hornet/ayon-nuke/client/ayon_nuke/startup/file_sequence/file_sequence.py"
+        # File paths localized from the hard coded path
+
+        startup = os.path.dirname(__file__)
+
+        hdu_loc = startup + "/hornet_deadline_utils.py"
+        dprm_loc = startup + "/hornet_publish_review_media.py"
+
+        fs_loc = startup + "/file_sequence/file_sequence.py"
 
         # Create specs
         spec1 = importlib.util.spec_from_file_location(

--- a/client/ayon_nuke/startup/test_file_sequence_import.py
+++ b/client/ayon_nuke/startup/test_file_sequence_import.py
@@ -1,10 +1,13 @@
 import importlib.util
 import sys
 import traceback
+import os
 
 print("=== Testing file_sequence import in isolation ===")
 
-fs_loc = "P:/dev/alexh_dev/ayon_v2/hornet/ayon-nuke/client/ayon_nuke/startup/file_sequence/file_sequence.py"
+#fs_loc = "P:/dev/alexh_dev/ayon_v2/hornet/ayon-nuke/client/ayon_nuke/startup/file_sequence/file_sequence.py"
+startup = os.path.dirname(__file__)
+fs_loc = startup + "/file_sequence/file_sequence.py"
 
 try:
     print(f"Creating spec from: {fs_loc}")

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -183,7 +183,8 @@ class HornetReviewMediaModel(BaseSettingsModel):
     _layout = "expanded"
     enabled: bool = SettingsField(title="Enabled")
     template_script: str = SettingsField(
-        default=r"P:/dev/alexh_dev/hornet_publish/hornet_publish_template.nk",
+        #default=r"P:/dev/alexh_dev/hornet_publish/hornet_publish_template.nk",
+        default=r"T:\util\nuke\scripts\publishTemplate\hornet_publish_template.nk",
         title="Review media template script location",
         description="The template script that will be rendered to generate review media.",
     )
@@ -423,7 +424,8 @@ DEFAULT_PUBLISH_PLUGIN_SETTINGS = {
     },
     "HornetReviewMedia": {
         "enabled": True,
-        "template_script": r"P:/dev/alexh_dev/hornet_publish/hornet_publish_template.nk",
+        "template_script": r"T:\util\nuke\scripts\publishTemplate\hornet_publish_template.nk",
+        #"template_script": r"P:/dev/alexh_dev/hornet_publish/hornet_publish_template.nk",
     },
     "IncrementScriptVersion": {
         "enabled": True,


### PR DESCRIPTION
Lots of paths in our add on were hard coded to the P: drive. Making them relative to allow functionality in instances like the black box.
